### PR TITLE
Accept client config struct and enhance todo demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # go-inceptiondb
-Inceptiondb client for golang
+
+Go client for the [InceptionDB](https://inceptiondb.hola.cloud) REST API.
+
+## Installation
+
+```
+go get github.com/holaql/go-inceptiondb
+```
+
+## Usage
+
+Create a client by providing the target database identifier and API
+credentials. The base URL defaults to the SaaS endpoint, but you can override
+it when self-hosting:
+
+```go
+client, err := inceptiondb.NewClient(inceptiondb.Config{
+        DatabaseID: "89744b21-5ab6-42a1-9209-3805c9c66834",
+        APIKey:     "<api-key>",
+        APISecret:  "<api-secret>",
+})
+if err != nil {
+        log.Fatal(err)
+}
+```
+
+Credentials are automatically sent on every request, so you only need to focus
+on the operations you want to perform. The client exposes helpers to manage
+collections, indexes and documents using idiomatic Go types.
+
+### Example project
+
+The `examples/todo` folder contains a small command-line application that uses a
+real database to manage a to-do list. Configure the required environment
+variables and run it with:
+
+```
+export INCEPTIONDB_DATABASE_ID="<database-id>"
+export INCEPTIONDB_API_KEY="<api-key>"
+export INCEPTIONDB_API_SECRET="<api-secret>"
+go run ./examples/todo
+```
+
+The program creates a collection, inserts a few tasks, reads back the results in
+pages and finally drops the collection so you can re-run it safely.
+
+### Testing
+
+Run the library tests with:
+
+```
+go test ./...
+```

--- a/client.go
+++ b/client.go
@@ -17,22 +17,27 @@ import (
 type Client struct {
 	baseURL    *url.URL
 	httpClient *http.Client
+	apiKey     string
+	apiSecret  string
+	databaseID string
 }
 
-// Option configures a Client instance.
-type Option func(*Client)
-
-// WithHTTPClient overrides the default HTTP client used to perform requests.
-func WithHTTPClient(h *http.Client) Option {
-	return func(c *Client) {
-		c.httpClient = h
-	}
+// Config captures the parameters required to establish a connection.
+type Config struct {
+	BaseURL    string
+	DatabaseID string
+	APIKey     string
+	APISecret  string
+	HTTPClient *http.Client
 }
 
-// NewClient creates a new Client pointing to the provided base URL.
-func NewClient(baseURL string, opts ...Option) (*Client, error) {
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, errors.New("base URL is required")
+const defaultBaseURL = "https://inceptiondb.hola.cloud"
+
+// NewClient creates a new Client from the provided configuration.
+func NewClient(cfg Config) (*Client, error) {
+	baseURL := strings.TrimSpace(cfg.BaseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
 	}
 
 	parsed, err := url.Parse(baseURL)
@@ -48,12 +53,10 @@ func NewClient(baseURL string, opts ...Option) (*Client, error) {
 
 	c := &Client{
 		baseURL:    parsed,
-		httpClient: http.DefaultClient,
-	}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(c)
-		}
+		httpClient: cfg.HTTPClient,
+		apiKey:     strings.TrimSpace(cfg.APIKey),
+		apiSecret:  strings.TrimSpace(cfg.APISecret),
+		databaseID: strings.TrimSpace(cfg.DatabaseID),
 	}
 	if c.httpClient == nil {
 		c.httpClient = http.DefaultClient
@@ -64,7 +67,7 @@ func NewClient(baseURL string, opts ...Option) (*Client, error) {
 // ListCollections retrieves the collections metadata available in the server.
 func (c *Client) ListCollections(ctx context.Context) ([]Collection, error) {
 	var collections []Collection
-	if err := c.doJSON(ctx, http.MethodGet, "/v1/collections", nil, &collections); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, c.collectionsPath(), nil, &collections); err != nil {
 		return nil, err
 	}
 	return collections, nil
@@ -80,7 +83,7 @@ func (c *Client) CreateCollection(ctx context.Context, req *CreateCollectionRequ
 		return nil, fmt.Errorf("encode create collection request: %w", err)
 	}
 	var result Collection
-	if err := c.doJSON(ctx, http.MethodPost, "/v1/collections", body, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, c.collectionsPath(), body, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -89,7 +92,7 @@ func (c *Client) CreateCollection(ctx context.Context, req *CreateCollectionRequ
 // GetCollection retrieves the metadata of a single collection.
 func (c *Client) GetCollection(ctx context.Context, collection string) (*Collection, error) {
 	var result Collection
-	if err := c.doJSON(ctx, http.MethodGet, collectionPath(collection), nil, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, c.collectionPath(collection), nil, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -97,7 +100,7 @@ func (c *Client) GetCollection(ctx context.Context, collection string) (*Collect
 
 // DropCollection deletes the collection and its indexes.
 func (c *Client) DropCollection(ctx context.Context, collection string) error {
-	return c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "dropCollection"), nil, nil)
+	return c.doJSON(ctx, http.MethodPost, c.collectionActionPath(collection, "dropCollection"), nil, nil)
 }
 
 // SetDefaults configures the default document used when inserting new rows.
@@ -107,7 +110,7 @@ func (c *Client) SetDefaults(ctx context.Context, collection string, defaults ma
 		return nil, fmt.Errorf("encode defaults request: %w", err)
 	}
 	result := map[string]any{}
-	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "setDefaults"), body, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, c.collectionActionPath(collection, "setDefaults"), body, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -116,7 +119,7 @@ func (c *Client) SetDefaults(ctx context.Context, collection string, defaults ma
 // ListIndexes returns the indexes registered in a collection.
 func (c *Client) ListIndexes(ctx context.Context, collection string) ([]Index, error) {
 	var result []Index
-	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "listIndexes"), nil, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, c.collectionActionPath(collection, "listIndexes"), nil, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -132,7 +135,7 @@ func (c *Client) CreateIndex(ctx context.Context, collection string, req *Create
 		return nil, fmt.Errorf("encode create index request: %w", err)
 	}
 	var result Index
-	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "createIndex"), body, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, c.collectionActionPath(collection, "createIndex"), body, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -145,7 +148,7 @@ func (c *Client) GetIndex(ctx context.Context, collection, name string) (*Index,
 		return nil, fmt.Errorf("encode get index request: %w", err)
 	}
 	var result Index
-	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "getIndex"), body, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, c.collectionActionPath(collection, "getIndex"), body, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -157,13 +160,13 @@ func (c *Client) DropIndex(ctx context.Context, collection, name string) error {
 	if err != nil {
 		return fmt.Errorf("encode drop index request: %w", err)
 	}
-	return c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "dropIndex"), body, nil)
+	return c.doJSON(ctx, http.MethodPost, c.collectionActionPath(collection, "dropIndex"), body, nil)
 }
 
 // Size returns statistics about the collection usage. This endpoint is experimental.
 func (c *Client) Size(ctx context.Context, collection string) (map[string]any, error) {
 	result := map[string]any{}
-	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "size"), nil, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, c.collectionActionPath(collection, "size"), nil, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -175,7 +178,7 @@ func (c *Client) InsertStream(ctx context.Context, collection string, reader io.
 	if reader == nil {
 		reader = http.NoBody
 	}
-	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "insert"), reader, "application/json")
+	return c.stream(ctx, http.MethodPost, c.collectionActionPath(collection, "insert"), reader, "application/json")
 }
 
 // InsertDocuments is a convenience helper that encodes the provided documents as
@@ -199,7 +202,7 @@ func (c *Client) Find(ctx context.Context, collection string, req *FindRequest) 
 	if err != nil {
 		return nil, fmt.Errorf("encode find request: %w", err)
 	}
-	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "find"), body, "application/json")
+	return c.stream(ctx, http.MethodPost, c.collectionActionPath(collection, "find"), body, "application/json")
 }
 
 // Patch applies a partial update to the documents matched by the query and
@@ -212,7 +215,7 @@ func (c *Client) Patch(ctx context.Context, collection string, req *PatchRequest
 	if err != nil {
 		return nil, fmt.Errorf("encode patch request: %w", err)
 	}
-	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "patch"), body, "application/json")
+	return c.stream(ctx, http.MethodPost, c.collectionActionPath(collection, "patch"), body, "application/json")
 }
 
 // Remove deletes the documents matched by the query and streams the removed
@@ -222,7 +225,7 @@ func (c *Client) Remove(ctx context.Context, collection string, req *RemoveReque
 	if err != nil {
 		return nil, fmt.Errorf("encode remove request: %w", err)
 	}
-	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "remove"), body, "application/json")
+	return c.stream(ctx, http.MethodPost, c.collectionActionPath(collection, "remove"), body, "application/json")
 }
 
 func (c *Client) stream(ctx context.Context, method, path string, body io.Reader, contentType string) (*JSONStream, error) {
@@ -278,6 +281,12 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, co
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
+	if c.apiKey != "" {
+		req.Header.Set("Api-Key", c.apiKey)
+	}
+	if c.apiSecret != "" {
+		req.Header.Set("Api-Secret", c.apiSecret)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -292,12 +301,23 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, co
 	return resp, nil
 }
 
-func collectionPath(collection string) string {
-	return "/v1/collections/" + url.PathEscape(collection)
+func (c *Client) collectionsPath() string {
+	if c.databaseID == "" {
+		return "/v1/collections"
+	}
+	return "/v1/databases/" + url.PathEscape(c.databaseID) + "/collections"
 }
 
-func collectionActionPath(collection, action string) string {
-	return collectionPath(collection) + ":" + action
+func (c *Client) collectionPath(collection string) string {
+	path := c.collectionsPath()
+	if collection == "" {
+		return path
+	}
+	return path + "/" + url.PathEscape(collection)
+}
+
+func (c *Client) collectionActionPath(collection, action string) string {
+	return c.collectionPath(collection) + ":" + action
 }
 
 func encodeJSONPayload(payload any) (io.Reader, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
 func TestOnline(t *testing.T) {
 	t.SkipNow()
-	c, err := NewClient("https://inceptiondb.io")
+	c, err := NewClient(Config{BaseURL: "https://inceptiondb.io"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,5 +68,66 @@ func TestEncodeQueryRequestPayload(t *testing.T) {
 	}
 	if _, ok := payload["filter"].(map[string]any); !ok {
 		t.Fatalf("filter type = %T, want map[string]any", payload["filter"])
+	}
+}
+
+func TestClientAddsCredentialsAndDatabasePath(t *testing.T) {
+	t.Parallel()
+
+	var (
+		receivedPath   string
+		receivedAPIKey string
+		receivedSecret string
+		receivedMethod string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedAPIKey = r.Header.Get("Api-Key")
+		receivedSecret = r.Header.Get("Api-Secret")
+		receivedMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(Config{
+		BaseURL:    server.URL,
+		DatabaseID: "my-db",
+		APIKey:     "my-key",
+		APISecret:  "my-secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	if _, err := client.ListCollections(context.Background()); err != nil {
+		t.Fatalf("ListCollections() error = %v", err)
+	}
+
+	if receivedMethod != http.MethodGet {
+		t.Fatalf("method = %s, want GET", receivedMethod)
+	}
+	if receivedPath != "/v1/databases/my-db/collections" {
+		t.Fatalf("path = %s, want /v1/databases/my-db/collections", receivedPath)
+	}
+	if receivedAPIKey != "my-key" {
+		t.Fatalf("Api-Key = %s, want my-key", receivedAPIKey)
+	}
+	if receivedSecret != "my-secret" {
+		t.Fatalf("Api-Secret = %s, want my-secret", receivedSecret)
+	}
+}
+
+func TestNewClientDefaultsBaseURL(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	if got, want := client.baseURL.String(), "https://inceptiondb.hola.cloud"; got != want {
+		t.Fatalf("baseURL = %s, want %s", got, want)
 	}
 }

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	inceptiondb "github.com/holaql/go-inceptiondb"
+)
+
+func main() {
+	databaseID := valueOrEnv("INCEPTIONDB_DATABASE_ID", "")
+	apiKey := valueOrEnv("INCEPTIONDB_API_KEY", "")
+	apiSecret := valueOrEnv("INCEPTIONDB_API_SECRET", "")
+
+	if databaseID == "" {
+		log.Fatal("INCEPTIONDB_DATABASE_ID must be set")
+	}
+	if apiKey == "" || apiSecret == "" {
+		log.Fatal("INCEPTIONDB_API_KEY and INCEPTIONDB_API_SECRET must be set")
+	}
+
+	cfg := inceptiondb.Config{
+		DatabaseID: databaseID,
+		APIKey:     apiKey,
+		APISecret:  apiSecret,
+	}
+	if baseURL := strings.TrimSpace(os.Getenv("INCEPTIONDB_BASE_URL")); baseURL != "" {
+		cfg.BaseURL = baseURL
+	}
+
+	client, err := inceptiondb.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	collectionName := "todo-items"
+	fmt.Printf("Using database %s, collection %s\n", databaseID, collectionName)
+
+	_ = client.DropCollection(ctx, collectionName)
+
+	if _, err := client.CreateCollection(ctx, &inceptiondb.CreateCollectionRequest{
+		Name: collectionName,
+		Defaults: map[string]any{
+			"completed": false,
+		},
+	}); err != nil {
+		log.Fatalf("create collection: %v", err)
+	}
+
+	todos := []map[string]any{
+		{"id": "1", "title": "Write demo", "completed": false},
+		{"id": "2", "title": "Test with real API", "completed": true},
+		{"id": "3", "title": "Share results", "completed": false},
+		{"id": "4", "title": "Record metrics", "completed": false},
+		{"id": "5", "title": "Celebrate", "completed": false},
+	}
+	stream, err := client.InsertDocuments(ctx, collectionName, toAnySlice(todos)...)
+	if err != nil {
+		log.Fatalf("insert documents: %v", err)
+	}
+	fmt.Println("Inserted documents:")
+	printStream(stream)
+
+	findStream, err := client.Find(ctx, collectionName, &inceptiondb.FindRequest{
+		QueryOptions: inceptiondb.QueryOptions{
+			Filter: map[string]any{"completed": false},
+			Limit:  2,
+		},
+	})
+	if err != nil {
+		log.Fatalf("find documents: %v", err)
+	}
+	fmt.Println("\nFirst page of incomplete tasks:")
+	printStream(findStream)
+
+	nextPage, err := client.Find(ctx, collectionName, &inceptiondb.FindRequest{
+		QueryOptions: inceptiondb.QueryOptions{
+			Filter: map[string]any{"completed": false},
+			Skip:   2,
+			Limit:  2,
+		},
+	})
+	if err != nil {
+		log.Fatalf("find documents: %v", err)
+	}
+	fmt.Println("\nSecond page of incomplete tasks:")
+	printStream(nextPage)
+
+	fmt.Println("\nCleaning up collection...")
+	if err := client.DropCollection(ctx, collectionName); err != nil {
+		log.Fatalf("drop collection: %v", err)
+	}
+}
+
+func toAnySlice(items []map[string]any) []any {
+	result := make([]any, len(items))
+	for i, item := range items {
+		result[i] = item
+	}
+	return result
+}
+
+func printStream(stream *inceptiondb.JSONStream) {
+	defer stream.Close()
+
+	err := inceptiondb.Iterate[map[string]any](stream, func(item *map[string]any) error {
+		data, err := json.MarshalIndent(item, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("stream error: %v", err)
+	}
+}
+
+func valueOrEnv(envKey, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(envKey)); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module inceptiondb
+module github.com/holaql/go-inceptiondb
 
-go 1.24.5
+go 1.24.3


### PR DESCRIPTION
## Summary
- switch the client constructor to take a Config struct with optional base URL defaulting to the SaaS service
- update the README and todo example to document the new configuration flow and demonstrate pagination
- cover the default base URL behaviour with a dedicated unit test

## Testing
- go test ./...
- INCEPTIONDB_DATABASE_ID=89744b21-5ab6-42a1-9209-3805c9c66834 INCEPTIONDB_API_KEY=2a794694-2d3f-4e8f-b129-b78df04410b7 INCEPTIONDB_API_SECRET=5b649694-a927-4f56-8896-44df5ab547f2 go run ./examples/todo


------
https://chatgpt.com/codex/tasks/task_e_68dab75b61bc832b9d41aa5d080e480e